### PR TITLE
Make choosing the theme a little bit easier

### DIFF
--- a/darkman.el
+++ b/darkman.el
@@ -19,7 +19,9 @@
 
 The two properties, ‘:light’ and ‘:dark’, expect as a value a
 symbol representing the name of the theme."
-  :type '(plist :value-type symbol)
+  :type `(plist :key-type (choice (const :tag "Light theme" :light)
+                                  (const :tag "Dark theme" :dark))
+          :value-type (choice ,@(mapcar (lambda (theme) (list 'const theme)) (custom-available-themes))))
   :package-version '(darkman . "0.1.0"))
 
 (defvar darkman--dbus-service "nl.whynothugo.darkman")


### PR DESCRIPTION
When using customize interface let user to choose themes from the list of available themes and not just any arbitrary symbol.
![image](https://user-images.githubusercontent.com/80391/212379361-ed533f99-8450-4d72-80cd-20341e2d3eb6.png)
