### PR TITLE
feat: load an appropriate theme on mode enable

### DIFF
--- a/darkman.el
+++ b/darkman.el
@@ -103,7 +103,8 @@ symbol representing the name of the theme."
 				       darkman--dbus-path
 				       darkman--dbus-interface
 				       "ModeChanged"
-				       #'darkman--mode-changed-signal-handler)))
+				       #'darkman--mode-changed-signal-handler))
+           (load-theme (darkman-get-theme)))
     (dbus-unregister-object darkman--dbus-signal)
     (setq darkman--dbus-signal nil)))
 


### PR DESCRIPTION
When the mode is enabled, load the theme to match the current darkman settings.