### PR TITLE
Disable load-theme confirmation

### DIFF
--- a/darkman.el
+++ b/darkman.el
@@ -140,7 +140,7 @@ when the mode is changed."
 				       darkman--dbus-interface
 				       "ModeChanged"
 				       #'darkman--mode-changed-signal-handler))
-           (load-theme (darkman-get-theme)))
+           (load-theme (darkman-get-theme) t))
     (dbus-unregister-object darkman--dbus-signal)
     (setq darkman--dbus-signal nil)))
 


### PR DESCRIPTION
I've recently configured the package in my config and I have a problem when I enable `darkman-mode` because the `load-theme` function requires confirmation to run the code from a theme.

In my case I have a systemd unit to start emacs where I can't do any confirmation. I suggest using the no-confirm argument to avoid this by default.