### PR TITLE
Handle dbus events instead of signals

### DIFF
--- a/TODO.org
+++ b/TODO.org
@@ -14,11 +14,11 @@
 
 * DONE Write up a Texinfo manual as an Org document
 We could use [[https://github.com/grtcdr/liaison/blob/main/doc/manual/liaison.org][this manual]] as a template.
-* BUG =load-theme= is called twice when =ModeChanged= is signaled      :help:
+* DONE =load-theme= is called twice when =ModeChanged= is signaled :help:
 This leads to a theme transition that isn't very smooth. I have no
 idea what might be causing this, but a peek into Darkman's source code
 could be helpful.
-* BUG Themes will sometimes switch infinitely                          :help:
+* DONE Themes will sometimes switch infinitely :help:
 This causes Emacs to go haywire. The first time this happened was a
 short time after merging [[pull:5][#5]]. I can reproduce it, but I haven't yet
 understood what exactly causes it to occur.

--- a/darkman.el
+++ b/darkman.el
@@ -110,25 +110,20 @@ when the mode is changed."
   "Get a theme from the ‘darkman-themes’ which corresponds to the current mode."
   (darkman--lookup-theme (darkman-get)))
 
-(defun darkman-load-theme-mode (new-mode)
-  "Load a theme associated with the NEW-MODE."
-  (let ((new-theme (darkman--lookup-theme new-mode)))
-    (unless darkman-switch-themes-silently
-      (message (format "Darkman switched to %s mode, switching to %s theme."
-                       new-mode new-theme)))
-    (load-theme new-theme)))
-
 (defun darkman--call-event-handler (interface property value)
   "Handle method_call events on Darkman DBus.
 
 INTERFACE is the name of the interface that is the target of the event.
-
 PROPERTY is the property that is modified by the event.
-
 VALUE is the new value of PROPERTY."
   (when (and (string-equal "Mode" property)
              (equal darkman--dbus-service interface))
-    (darkman-load-theme-mode (car value))))
+    (let* ((new-mode (car value))
+           (new-theme (darkman--lookup-theme new-mode)))
+      (unless darkman-switch-themes-silently
+        (message (format "Darkman switched to %s mode, switching to %s theme."
+                         new-mode new-theme)))
+      (load-theme new-theme))))
 
 (defun darkman--check-dbus-service ()
   "Return non-nil if the Darkman service is available."

--- a/darkman.el
+++ b/darkman.el
@@ -6,6 +6,7 @@
 ;; Maintainer: Aziz Ben Ali <tahaaziz.benali@esprit.tn>
 ;; Homepage: https://grtcdr.tn/darkman.el/
 ;; Version: 0.4.0
+;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: convenience
 
 ;; This file is not part of GNU Emacs.
@@ -109,13 +110,25 @@ when the mode is changed."
   "Get a theme from the ‘darkman-themes’ which corresponds to the current mode."
   (darkman--lookup-theme (darkman-get)))
 
-(defun darkman--mode-changed-signal-handler (new-mode)
-  "Handle the ModeChanged signal.  NEW-MODE is the new mode."
+(defun darkman-load-theme-mode (new-mode)
+  "Load a theme associated with the NEW-MODE."
   (let ((new-theme (darkman--lookup-theme new-mode)))
     (unless darkman-switch-themes-silently
       (message (format "Darkman switched to %s mode, switching to %s theme."
-		       new-mode new-theme)))
+                       new-mode new-theme)))
     (load-theme new-theme)))
+
+(defun darkman--call-event-handler (interface property value)
+  "Handle method_call events on Darkman DBus.
+
+INTERFACE is the name of the interface that is the target of the event.
+
+PROPERTY is the property that is modified by the event.
+
+VALUE is the new value of PROPERTY."
+  (when (and (string-equal "Mode" property)
+             (equal darkman--dbus-service interface))
+    (darkman-load-theme-mode (car value))))
 
 (defun darkman--check-dbus-service ()
   "Return non-nil if the Darkman service is available."
@@ -133,13 +146,14 @@ when the mode is changed."
       (progn
 	(and (darkman--check-dbus-service)
 	     (setq darkman--dbus-signal
-		   (dbus-register-signal
+		   (dbus-register-monitor
 		    :session
-		    darkman--dbus-service
-		    darkman--dbus-path
-		    darkman--dbus-interface
-		    "ModeChanged"
-		    #'darkman--mode-changed-signal-handler))
+                    #'darkman--call-event-handler
+                    :type "method_call"
+                    :destination darkman--dbus-service
+                    :path  darkman--dbus-path
+		    :interface "org.freedesktop.DBus.Properties"
+		    :member "Set"))
 	     (load-theme (darkman-get-theme)))
 	(when (daemonp)
 	  (remove-hook 'server-after-make-frame-hook #'darkman-mode)))


### PR DESCRIPTION
Emacs gets several signals related with different events of dbus which makes it appear that it receives the same signals multiple times as commented in Because we don't need to be listening all kinds of signals, we could just listen for events over a dbus name by using `dbus-register-monitor`.

Along with this, the commit includes:
* Replace `darkman--mode-changed-signal-handler` with `darkman--call-event-handler` to be a real handler of all method_call events from darkman dbus.
* Create `darkman-load-theme-mode` function that will be called every time `Mode` property in `nl.whynothugo.darkman` interface is called.
* Add Package-Requires Emacs 28.1 to fix warnings from package-lint
* Set related issue tasks as DONE
* Fix #10 as commented @grtcdr in #issuecomment-1447145236